### PR TITLE
WIP: Add conformal predictions for regression

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -4138,6 +4138,32 @@ class TabularPredictor:
                 error_message = f"{error_message} `.{message_suffix}`."
             raise AssertionError(error_message)
 
+    def get_conformal_predictions(self, test_data, model: str) -> (List[np.ndarray], List[np.ndarray], List[np.ndarray]):
+        self._assert_is_fit("get_conformal_predictions")
+        if self.problem_type != REGRESSION:
+            raise AssertionError(f'conformal predictions only implemented for problem_type="{REGRESSION}" (problem_type is "{self.problem_type}")')
+
+        cross_val_outputs, cross_val_targets, cross_test_outputs = [], [], []
+
+        model_pred_val = self.predict_multi(models=[model])[model]
+        model_obj = self._trainer.load_model(model)
+
+        test_internal = self.transform_features(data=test_data, model=model)
+        y_pred_test_per_fold = model_obj.predict_folds(test_internal)
+
+        val_data_source = "val" if self._trainer.has_val else "train"
+        _, y_val = self.load_data_internal(data=val_data_source, return_X=False, return_y=True)
+
+        n_splits = len(model_obj.models)  # FIXME: Will break with multiple repeats
+        for i in range(n_splits):
+            train_idx, val_idx = model_obj._get_train_val_indices_for_fold(fold=i, repeat=0)
+            cross_val_output = model_pred_val[val_idx]  # FIXME: Maybe loc
+            cross_val_outputs.append(cross_val_output)
+            cross_val_targets.append(y_val[val_idx].values)
+            cross_test_outputs.append(y_pred_test_per_fold[i])
+
+        return cross_val_outputs, cross_val_targets, cross_test_outputs
+
 
 # Location to store WIP functionality that will be later added to TabularPredictor
 class _TabularPredictorExperimental(TabularPredictor):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Example code:

```python3
import pandas as pd
from sklearn.metrics import mean_squared_error

from fortuna.conformal import CVPlusConformalRegressor
from fortuna.metric.regression import prediction_interval_coverage_probability

from autogluon.tabular import TabularPredictor


# TODO: Make repeated bagging work
# TODO: Test for non-uniform indices
# TODO: Figure out if WeightedEnsemble can work
if __name__ == '__main__':
    label = 'age'
    train_data = pd.read_csv('https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')
    subsample_size = 3000  # subsample subset of data for faster demo, try setting this to much larger values
    if subsample_size is not None and subsample_size < len(train_data):
        train_data = train_data.sample(n=subsample_size, random_state=0)
    train_data = train_data.reset_index(drop=True)  # FIXME: Errors if this isn't done
    test_data = pd.read_csv('https://autogluon.s3.amazonaws.com/datasets/Inc/test.csv')

    error = 0.2

    predictor: TabularPredictor = TabularPredictor(label=label, eval_metric='mse', problem_type='regression').fit(
        train_data, num_bag_folds=5,
        hyperparameters={'FASTAI': {}, 'GBM': {}, 'XGB': {}},
    )

    model_names = predictor.get_model_names()

    for model_name in model_names:
        model = predictor._trainer.load_model(model_name)
        num_folds = len(model.models)

        print(f'Conformal Predictions for {model_name}:')

        X_test_internal = predictor.transform_features(data=test_data, model=model_name)
        y_test_internal = predictor.transform_labels(labels=test_data[label])
        y_pred_test = model.predict(X_test_internal)

        if num_folds <= 1:
            print(f'\tSkipping due to num_folds={num_folds}')
            mse = mean_squared_error(y_true=y_test_internal, y_pred=y_pred_test)
            print(f'\t\tmse BagEns: {mse}')
            continue
        cross_val_outputs, cross_val_targets, cross_test_outputs = predictor.get_conformal_predictions(
            test_data=test_data,
            model=model_name,
        )
        n_splits = len(cross_test_outputs)
        y_pred_test_per_fold = model.predict_folds(X_test_internal)

        cvplus_interval = CVPlusConformalRegressor().conformal_interval(
            cross_val_outputs=cross_val_outputs,
            cross_val_targets=cross_val_targets,
            cross_test_outputs=cross_test_outputs,
            error=error,
        )
        cvplus_coverage = prediction_interval_coverage_probability(
            cvplus_interval[:, 0], cvplus_interval[:, 1], y_test_internal
        )
        mse = mean_squared_error(y_true=y_test_internal, y_pred=y_pred_test)
        print(f"\tDesired coverage: {1 - error:.4f}\n"
              f"\tCV+ empirical coverage: {cvplus_coverage:.4f}")
        for i in range(20):
            ground_truth = y_test_internal.iloc[i]
            interval = cvplus_interval[i, :]
            lower_interval, upper_interval = interval
            is_within_interval = (ground_truth >= lower_interval) and (ground_truth < upper_interval)
            print(f'\tGT: {ground_truth}\t| {lower_interval:.2f}\t| {upper_interval:.2f}\t| {is_within_interval}')
        print(f'\t\tmse BagEns: {mse:.2f}')
        for i in range(n_splits):
            mse_fold = mean_squared_error(y_true=y_test_internal, y_pred=cross_test_outputs[i])
            print(f'\t\tmse fold {i}: {mse_fold:.2f}')

```

Example output:
```
Conformal Predictions for LightGBM_BAG_L1:
No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)
/home/ubuntu/.conda/envs/code/lib/python3.8/site-packages/fortuna/metric/regression.py:128: FutureWarning: Support for multi-dimensional indexing (e.g. `obj[:, None]`) is deprecated and will be removed in a future version.  Convert to a numpy array before indexing instead.
  targets = targets[:, None]
	Desired coverage: 0.8000
	CV+ empirical coverage: 0.8008
	GT: 31	| 28.44	| 55.29	| True
	GT: 17	| 13.60	| 39.06	| True
	GT: 47	| 31.70	| 57.04	| True
	GT: 21	| 10.50	| 36.01	| True
	GT: 17	| 9.17	| 34.43	| True
	GT: 58	| 31.87	| 57.16	| False
	GT: 42	| 30.20	| 55.90	| True
	GT: 60	| 33.62	| 58.86	| False
	GT: 20	| 25.91	| 51.51	| False
	GT: 29	| 26.48	| 52.05	| True
	GT: 36	| 32.84	| 58.73	| True
	GT: 72	| 40.90	| 66.44	| False
	GT: 37	| 22.39	| 47.75	| True
	GT: 43	| 33.36	| 58.88	| True
	GT: 67	| 44.75	| 70.54	| True
	GT: 40	| 30.58	| 55.85	| True
	GT: 49	| 45.04	| 70.76	| True
	GT: 52	| 33.81	| 59.15	| True
	GT: 45	| 34.87	| 60.26	| True
	GT: 19	| 7.71	| 33.16	| True
		mse BagEns: 105.70
		mse fold 0: 108.32
		mse fold 1: 108.35
		mse fold 2: 108.06
		mse fold 3: 106.65
		mse fold 4: 106.95
Conformal Predictions for NeuralNetFastAI_BAG_L1:
	Desired coverage: 0.8000
	CV+ empirical coverage: 0.8162
	GT: 31	| 21.00	| 46.90	| True
	GT: 17	| 12.20	| 37.74	| True
	GT: 47	| 29.79	| 55.46	| True
	GT: 21	| 11.07	| 36.47	| True
	GT: 17	| 6.28	| 31.95	| True
	GT: 58	| 32.56	| 57.97	| False
	GT: 42	| 31.93	| 57.25	| True
	GT: 60	| 31.15	| 56.72	| False
	GT: 20	| 20.44	| 45.78	| False
	GT: 29	| 24.69	| 50.73	| True
	GT: 36	| 36.06	| 61.49	| False
	GT: 72	| 44.26	| 69.51	| False
	GT: 37	| 19.95	| 45.70	| True
	GT: 43	| 33.78	| 60.25	| True
	GT: 67	| 39.44	| 65.74	| False
	GT: 40	| 29.92	| 55.32	| True
	GT: 49	| 31.10	| 58.06	| True
	GT: 52	| 31.01	| 56.36	| True
	GT: 45	| 36.91	| 62.79	| True
	GT: 19	| 7.89	| 34.14	| True
		mse BagEns: 103.81
		mse fold 0: 107.65
		mse fold 1: 108.11
		mse fold 2: 107.91
		mse fold 3: 106.78
		mse fold 4: 108.01
Conformal Predictions for XGBoost_BAG_L1:
/home/ubuntu/.conda/envs/code/lib/python3.8/site-packages/fortuna/metric/regression.py:128: FutureWarning: Support for multi-dimensional indexing (e.g. `obj[:, None]`) is deprecated and will be removed in a future version.  Convert to a numpy array before indexing instead.
  targets = targets[:, None]
	Desired coverage: 0.8000
	CV+ empirical coverage: 0.8133
	GT: 31	| 27.03	| 53.80	| True
	GT: 17	| 12.27	| 38.07	| True
	GT: 47	| 30.06	| 56.11	| True
	GT: 21	| 10.04	| 35.85	| True
	GT: 17	| 6.50	| 32.18	| True
	GT: 58	| 30.74	| 56.49	| False
	GT: 42	| 30.03	| 55.85	| True
	GT: 60	| 32.07	| 57.74	| False
	GT: 20	| 22.02	| 48.37	| False
	GT: 29	| 27.74	| 53.39	| True
	GT: 36	| 31.35	| 57.33	| True
	GT: 72	| 48.51	| 75.71	| True
	GT: 37	| 25.46	| 51.25	| True
	GT: 43	| 30.24	| 55.96	| True
	GT: 67	| 42.30	| 68.55	| True
	GT: 40	| 27.07	| 52.84	| True
/home/ubuntu/.conda/envs/code/lib/python3.8/site-packages/fortuna/metric/regression.py:128: FutureWarning: Support for multi-dimensional indexing (e.g. `obj[:, None]`) is deprecated and will be removed in a future version.  Convert to a numpy array before indexing instead.
  targets = targets[:, None]
	GT: 49	| 38.73	| 66.48	| True
	GT: 52	| 32.59	| 58.38	| True
	GT: 45	| 34.35	| 60.23	| True
	GT: 19	| 7.03	| 32.77	| True
		mse BagEns: 105.30
		mse fold 0: 109.28
		mse fold 1: 107.37
		mse fold 2: 107.26
		mse fold 3: 107.46
		mse fold 4: 107.87
Conformal Predictions for WeightedEnsemble_L2:
	Skipping due to num_folds=1
		mse BagEns: 102.36561723277092
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
