### PR TITLE
add cross val for multiclass

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1715,7 +1715,7 @@ class TabularPredictor:
                     )
                 )
         return results
-    
+
     def get_pred_from_proba(self, y_pred_proba: pd.DataFrame | np.ndarray, decision_threshold: float | None = None) -> pd.Series | np.array:
         """
         Given prediction probabilities, convert to predictions.
@@ -4248,7 +4248,7 @@ class TabularPredictor:
 
             return cross_val_outputs, cross_val_targets, cross_test_outputs
 
-        if self.problem_type == MULTICLASS:
+        if self.problem_type in [BINARY, MULTICLASS]:
             cross_val_probs, cross_val_targets, cross_test_probs = [], [], []
 
             model_probs_val = self.predict_proba_multi(models=[model])[model]

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1629,7 +1629,7 @@ class TabularPredictor:
         data = self._get_dataset(data)
         return self._learner.predict_proba(X=data, model=model, as_pandas=as_pandas, as_multiclass=as_multiclass, transform_features=transform_features)
 
-    def predict_conformal(
+    def predict_conformal_set(
         self,
         val_data: str | TabularDataset | pd.DataFrame,
         test_data: str | TabularDataset | pd.DataFrame,


### PR DESCRIPTION
Espose the cross validation quantities necessary for multiclass. The same logic may work also for binary classification, but the implementation was tested only for `self.problem_type == "multiclass"`.
